### PR TITLE
Added extra run step

### DIFF
--- a/nfs_setup.sh
+++ b/nfs_setup.sh
@@ -10,3 +10,4 @@ for mnt in "${mounts[@]}"; do
 done
 
 exec runsvdir /etc/sv
+/etc/sv/nfs/run


### PR DESCRIPTION
I could only reproducibly get NFS to startup and run by running this after the container had started:

$ docker exec -it nfs /bin/bash
root@64d833228a84:/# /etc/sv/nfs/run

Trying this in the script that gets run.
